### PR TITLE
go.etcd.io/bbolt requires an alias

### DIFF
--- a/store/boltdb/boltdb.go
+++ b/store/boltdb/boltdb.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/abronan/valkeyrie"
 	"github.com/abronan/valkeyrie/store"
-	"go.etcd.io/bbolt"
+	bbolt "go.etcd.io/bbolt"
 )
 
 var (


### PR DESCRIPTION
The alias appears to be required now, certainly to use in modules enabled projects.