### PR TITLE
Fix import path

### DIFF
--- a/store/etcd/v3/etcd.go
+++ b/store/etcd/v3/etcd.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/abronan/valkeyrie"
 	"github.com/abronan/valkeyrie/store"
-	etcd "go.etcd.io/etcd/clientv3"
+	etcd "github.com/coreos/etcd/clientv3"
 	"go.etcd.io/etcd/clientv3/concurrency"
 )
 


### PR DESCRIPTION
As etcd repo doesn't rename repenedencies in Go sources yes, this dependency path is causing an import error:

cannot use s.client (type *"go.etcd.io/etcd/clientv3".Client) as type *"github.com/coreos/etcd/clientv3".Client in argument to concurrency.NewSession

This import path change fixes the error