### PR TITLE
Fix the import statements in etcd.go.

### DIFF
--- a/store/etcd/v3/etcd.go
+++ b/store/etcd/v3/etcd.go
@@ -10,7 +10,7 @@ import (
 	"github.com/abronan/valkeyrie"
 	"github.com/abronan/valkeyrie/store"
 	etcd "github.com/coreos/etcd/clientv3"
-	"go.etcd.io/etcd/clientv3/concurrency"
+	"github.com/coreos/etcd/clientv3/concurrency"
 )
 
 const (


### PR DESCRIPTION
Can't use this workaround
(https://github.com/etcd-io/etcd/issues/11563#issuecomment-620474246)
if valkeyrie mixes go.etcd.io/etcd with github.com/coreos/etcd for some
reason.

```
github.com/abronan/valkeyrie/store/etcd/v3
../../../go/pkg/mod/github.com/abronan/valkeyrie@v0.0.0-20191010124425-1ae9442de16e/store/etcd/v3/etcd.go:422:42: cannot use s.client (type *"github.com/coreos/etcd/clientv3".Client) as type *"go.etcd.io/etcd/clientv3".Client in argument to concurrency.NewSession
../../../go/pkg/mod/github.com/abronan/valkeyrie@v0.0.0-20191010124425-1ae9442de16e/store/etcd/v3/etcd.go:477:87: cannot use l.session.Lease() (type "go.etcd.io/etcd/clientv3".LeaseID) as type "github.com/coreos/etcd/clientv3".LeaseID in argument to "github.com/coreos/etcd/clientv3".WithLease
```